### PR TITLE
Breaks Python garbage collection

### DIFF
--- a/notifier/threads.py
+++ b/notifier/threads.py
@@ -79,8 +79,12 @@ class Simple( object ):
 			trace = None
 			exc_info = None
 		except BaseException as exc:
-			exc_info = sys.exc_info()
-			trace = traceback.format_tb( sys.exc_info()[ 2 ] )
+			try:
+				etype, value, tb = sys.exc_info()
+				trace = traceback.format_tb(tb)
+				exc_info = (etype, value, None)
+			finally:
+				etype = value = tb = None
 			result = exc
 		self.lock()
 		try:

--- a/notifier/threads.py
+++ b/notifier/threads.py
@@ -66,10 +66,6 @@ class Simple( object ):
 			notifier.dispatcher_add( _simple_threads_dispatcher )
 		_threads.append( self )
 
-	def __del__( self ):
-		if self._exc_info is not None:
-			del self._exc_info
-
 	def run( self ):
 		"""Starts the thread"""
 		self._thread.start()


### PR DESCRIPTION
python-notifier.thread.Simple objects are not garbage collected as they implement the `__del__` method. See individual commit message and [Bug #47114](http://forge.univention.org/bugzilla/show_bug.cgi?id=47114) for more details.