### PR TITLE
Fix OverflowError when system time changes

### DIFF
--- a/notifier/nf_generic.py
+++ b/notifier/nf_generic.py
@@ -53,6 +53,7 @@ __min_timer = None
 __in_step = False
 __step_depth = 0
 __step_depth_max = 0
+__uint32_max = 2**31 - 1
 
 _options = {
 	'recursive_depth' : 10,
@@ -204,7 +205,7 @@ def step( sleep = True, external = True ):
 					continue
 				nextCall = timestamp - now
 				if timeout is None or nextCall < timeout:
-					if nextCall > 0:
+					if nextCall > 0 and nextCall < __uint32_max:
 						timeout = nextCall
 					else:
 						timeout = 0


### PR DESCRIPTION
```
    notifier.loop()
  File "/usr/lib/pymodules/python2.7/notifier/nf_generic.py", line 286, in loop
    step()
  File "/usr/lib/pymodules/python2.7/notifier/nf_generic.py", line 219, in step
    fds = __poll.poll( timeout )
OverflowError: Python int too large to convert to C int
```

This traceback occurs when the system time is changed during a running python-notifier main loop.

See also: https://forge.univention.org/bugzilla/show_bug.cgi?id=44222