### PR TITLE
Fix python 3 notifier callback comparability

### DIFF
--- a/notifier/__init__.py
+++ b/notifier/__init__.py
@@ -91,7 +91,8 @@ def init(model=GENERIC, **kwargs):
 		nf_impl._init()
 
 
-class Callback:
+class Callback(object):
+
 	def __init__(self, function, *args, **kwargs):
 		self._function = function
 		self._args = args
@@ -103,17 +104,27 @@ class Callback:
 			tmp.extend(self._args)
 		return self._function(*tmp, **self._kwargs)
 
-	def __cmp__(self, rvalue):
-		if not callable(rvalue):
-			return -1
+	def __lt__(self, other):
+		return self._function < (other._function if isinstance(other, Callback) else other) if callable(other) else NotImplemented
 
-		if (isinstance(rvalue, Callback) and self._function == rvalue._function) or self._function == rvalue:
-			return 0
+	def __le__(self, other):
+		return self._function <= (other._function if isinstance(other, Callback) else other) if callable(other) else NotImplemented
 
-		return -1
+	def __eq__(self, other):
+		return self._function == (other._function if isinstance(other, Callback) else other) if callable(other) else NotImplemented
 
-	def __nonzero__(self):
+	def __ne__(self, other):
+		return self._function != (other._function if isinstance(other, Callback) else other) if callable(other) else NotImplemented
+
+	def __ge__(self, other):
+		return self._function >= (other._function if isinstance(other, Callback) else other) if callable(other) else NotImplemented
+
+	def __gt__(self, other):
+		return self._function > (other._function if isinstance(other, Callback) else other) if callable(other) else NotImplemented
+
+	def __bool__(self):
 		return bool(self._function)
+	__nonzero__ = __bool__
 
 	def __hash__(self):
-		return self._function.__hash__()
+		return hash(self._function)

--- a/notifier/signals.py
+++ b/notifier/signals.py
@@ -40,13 +40,15 @@ class SignalExistsError(Exception):
 
 
 class Signal(object):
+
 	def __init__(self, name):
 		self.name = name
 		self.__callbacks = []
 
 	def emit(self, *args):
-		for cb in self.__callbacks:
-			cb(*args)
+		for cb in self.__callbacks[:]:
+			if cb(*args):
+				self.disconnect(cb)
 
 	def connect(self, callback):
 		self.__callbacks.append(callback)
@@ -54,7 +56,7 @@ class Signal(object):
 	def disconnect(self, callback):
 		try:
 			self.__callbacks.remove(callback)
-		except:
+		except ValueError:
 			pass
 
 	def __str__(self):
@@ -62,6 +64,7 @@ class Signal(object):
 
 
 class Provider(object):
+
 	def __init__(self):
 		self.__signals = {}
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import notifier
+
+
+def foo():
+	pass
+
+
+def bar():
+	pass
+
+
+def test_callback_equality():
+	callbacks = [notifier.Callback(foo), notifier.Callback(bar, 1, 2, 3)]
+	assert notifier.Callback(foo) in callbacks
+	assert foo in callbacks
+	callbacks.remove(notifier.Callback(foo, 3, 2, 1))
+	callbacks.remove(bar)
+	assert not callbacks

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -29,7 +29,7 @@ import time
 import pytest
 
 
-class TestSignal(signals.Provider):
+class SignalTest(signals.Provider):
 	def __init__(self):
 		signals.Provider.__init__(self)
 		self.signal_new('test-signal')
@@ -37,7 +37,7 @@ class TestSignal(signals.Provider):
 
 @pytest.fixture(scope='module')
 def global_data():
-	return {'test': TestSignal()}
+	return {'test': SignalTest()}
 
 
 signals.new('test-signal')
@@ -60,7 +60,7 @@ def test_signals_obj(global_data):
 	signal_cb = mock.Mock()
 	notifier.init(notifier.GENERIC)
 	global_data['test'].signal_connect(
-		'test-signal', notifier.Callback(signal_cb, 1, 2, 'TestSignal signal'))
+		'test-signal', notifier.Callback(signal_cb, 1, 2, 'SignalTest signal'))
 	notifier.timer_add(2000, notifier.Callback(timer_cb, 7))
 	for i in range(3):
 		notifier.step()


### PR DESCRIPTION
* `__cmp__` has been removed in python 3. Provide `__lt__` etc.
* Add functionality if callback returns True to disconnect it.