### PR TITLE
Bug #51781: unregister closed sockets

### DIFF
--- a/notifier/nf_generic.py
+++ b/notifier/nf_generic.py
@@ -108,8 +108,10 @@ def socket_remove(id, condition=IO_READ):
 
 	try:
 		fd = _get_fd(id)
+		if fd < 0:
+			raise ValueError()
 		valid = True
-	except:
+	except Exception:
 		fd = None
 		valid = False
 		# file descriptor already closed


### PR DESCRIPTION
If a socket was closed, it was not removed from `__sock_objects` and
was checked again and again without any timeout in between. That
resulted in a high CPU load.